### PR TITLE
ESLint error fixes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,7 @@ function initUI() {
 
   const fileSelection = $('input#importJson');
 
-   $('button#importJson').onclick = () => {
+  $('button#importJson').onclick = () => {
     fileSelection.click();
   };
 
@@ -125,7 +125,7 @@ function initUI() {
     const channelIdField = $('input#channelId');
 
     // Force the guild id to be ourself (@me)
-    const guildIdField = $("input#guildId");
+    const guildIdField = $('input#guildId');
     guildIdField.value = '@me';
 
     // Set author id in case its not set already


### PR DESCRIPTION
Running `npm run test` results in the following ESLint errors, that this commit fixes:
```
  114:1   error  Expected indentation of 2 spaces but found 3  indent
  128:28  error  Strings must use singlequote                  quotes
```